### PR TITLE
Fix handling of created or deleted groups

### DIFF
--- a/ansible_inventory_diff/__main__.py
+++ b/ansible_inventory_diff/__main__.py
@@ -59,8 +59,8 @@ def find_changes(inventory_a, dir_a, inventory_b, dir_b):
 
     a_tree = build_tree(data_a)
     changed_groups = dict()
-    changed_groups['deleted'] = search_groups(changed_hosts['deleted'], a_tree)
-    changed_groups['created'] = search_groups(changed_hosts['created'], build_tree(data_b))
+    changed_groups['deleted'] = search_groups(list(changed_hosts['deleted']), a_tree)
+    changed_groups['created'] = search_groups(list(changed_hosts['created']), build_tree(data_b))
     changed_groups['updated'] = search_groups(list(changed_hosts['updated'].keys()), a_tree)
     return changed_hosts, changed_groups
 


### PR DESCRIPTION
I was getting the following error when removing a group: 
```Traceback (most recent call last):
  File "/usr/local/bin/ansible-inventory-diff", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/ansible_inventory_diff/__main__.py", line 97, in main
    run(sys.argv[1:])
  File "/usr/local/lib/python3.7/site-packages/ansible_inventory_diff/__main__.py", line 77, in run
    changed_hosts, changed_groups = find_changes(*args)
  File "/usr/local/lib/python3.7/site-packages/ansible_inventory_diff/__main__.py", line 70, in find_changes
    changed_groups['deleted'] = search_groups(changed_hosts['deleted'], a_tree)
  File "/usr/local/lib/python3.7/site-packages/ansible_inventory_diff/tree.py", line 23, in search_groups
    parents = set(tree[changed_hosts[0]]['parents'])
TypeError: 'set' object is not subscriptable```